### PR TITLE
Added CSS file for Icon Font & modified bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,13 +2,6 @@
   "name": "material-design-icons",
   "author": "Material Design Authors",
   "description": "Material Design icons by Google",
-  "main": [
-    "iconfont/material-icons.css",
-    "iconfont/MaterialIcons-Regular.eot",
-    "iconfont/MaterialIcons-Regular.ttf",
-    "iconfont/MaterialIcons-Regular.woff",
-    "iconfont/MaterialIcons-Regular.woff2"
-  ],
   "keywords": [
     "icons",
     "material",

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,13 @@
   "name": "material-design-icons",
   "author": "Material Design Authors",
   "description": "Material Design icons by Google",
+  "main": [
+    "iconfont/material-icons.css",
+    "iconfont/MaterialIcons-Regular.eot",
+    "iconfont/MaterialIcons-Regular.ttf",
+    "iconfont/MaterialIcons-Regular.woff",
+    "iconfont/MaterialIcons-Regular.woff2"
+  ],
   "keywords": [
     "icons",
     "material",

--- a/iconfont/material-icons.css
+++ b/iconfont/material-icons.css
@@ -1,0 +1,38 @@
+@font-face {
+  font-family: 'Material Icons';
+  font-style: normal;
+  font-weight: 400;
+  src: url(MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: local('Material Icons'),
+       local('MaterialIcons-Regular'),
+       url(MaterialIcons-Regular.woff2) format('woff2'),
+       url(MaterialIcons-Regular.woff) format('woff'),
+       url(MaterialIcons-Regular.ttf) format('truetype');
+}
+
+.material-icons {
+  font-family: 'Material Icons';
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;  /* Preferred icon size */
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  line-height: 1;
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+
+  /* Support for all WebKit browsers. */
+  -webkit-font-smoothing: antialiased;
+  /* Support for Safari and Chrome. */
+  text-rendering: optimizeLegibility;
+
+  /* Support for Firefox. */
+  -moz-osx-font-smoothing: grayscale;
+
+  /* Support for IE. */
+  font-feature-settings: 'liga';
+}


### PR DESCRIPTION
Added CSS file for Icon Font so they are usable right from package without additional work (copy + paste it is). Also added that new CSS file and Icon Font files to main block of bower.json so they are usable with bower-installer (for the folks that need only Icon Font)