### PR TITLE
Added require('material-design-icons').PATH

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+var join = require('path').join;
+
+module.exports = {
+  PATH: join(
+    __dirname,
+    'material-design-icons'
+  ),
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "material-design-icons",
   "version": "2.1.1",
   "description": "Material Design icons by Google",
-  "main": "index.html",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/google/material-design-icons"


### PR DESCRIPTION
It would improve the developer ergonomics if we made hosting this package as easy as possible.

For instance, if you are working on an app locally/offline and want to use Material assets, with this change you'd be able to:

```javascript
server.map(
  STATIC_PREFIX + '/material-design-icons',
  require('material-design-icons').PATH,
);
```

and all the icons in this package would be available at http://localhost:8080/static/material-design-icons/  Of course, you'd want something more robust for production, but this would be an improvement for development.

Thoughts, @shyndman, @jestelle?