### PR TITLE
Added missing icon category for Gulp file

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -17,6 +17,7 @@ const ICON_CATEGORIES = [
   'av',
   'communication',
   'content',
+  'device',
   'editor',
   'file',
   'hardware',


### PR DESCRIPTION
Added the icon category 'device' to gulpfile.bable.js