### PR TITLE
Changed npm URL from npmjs.io to npmjs.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@ are making available.</p>
 <p>Install the icons using the <a href="http://bower.io/">Bower</a> package manager.</p>
 <pre><code>$ bower install material-design-icons
 </code></pre><h2 id="installing-icons-from-npm">Installing icons from npm</h2>
-<p>Install the icons using <a href="http://npmjs.io/">npm</a> package manager.</p>
+<p>Install the icons using <a href="http://npmjs.com/">npm</a> package manager.</p>
 <pre><code>$ npm install material-design-icons
 </code></pre><p><hr></p>
 <h1 id="icon-font-for-the-web">Icon font for the web</h1>


### PR DESCRIPTION
Changed URL from `npmjs.io` to `npmjs.com` because the `npmjs.io` URL was broken.