### PR TITLE
README: remove confusing re-sell requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ Read more in the [font portion](https://google.github.io/material-design-icons/#
 ## License
 
 We have made these icons available for you to incorporate into your products under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt). Feel free to remix and re-share these icons and documentation in your products.
-We'd love attribution in your app's *about* screen, but it's not required. The only thing we ask is that you not re-sell these icons.
+We'd love attribution in your app's *about* screen, but it's not required.


### PR DESCRIPTION
Please merge this if you want to material-design-icons to be used under the terms of Apache-2.0, which allows commercial use.

This additional "requirement" is under a "License" section of your README and it makes it very confusing.

I am a Debian Developer and there is software that I maintain that comes with files from material-design-icons. However, I could not include these files in Debian if they are licensed with the "do not re-sell" requirement as it would make them non-free.

Related issue: #424