### PR TITLE
Restricting web icons to one em

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# dependencies
 node_modules
+
+# os
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ If you wish to use the icon set with Polymer, we recommend consuming them via th
 
 We have made these icons available for you to incorporate them into your products under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt). Feel free to remix and re-share these icons and documentation in your products.
 We'd love attribution in your app's *about* screen, but it's not required. The only thing we ask is that you not re-sell these icons.
+
+## Troubleshooting: Known issues
+
+Add known issues or strange behavior in this section.
+
+### Web icon strange behavior
+
+If a web icon name is formed from two names connected with `_` and the icon name is found it will display correctly. If the second name part can't be found but the first one can it will display the icon matching the first name part (i.e. `image_badname` will display the `image` icon). In case the first part can't be found it will display an empty field with the size of `.material-icons` `font-size` property.

--- a/iconfont/material-icons.css
+++ b/iconfont/material-icons.css
@@ -16,6 +16,8 @@
   font-style: normal;
   font-size: 24px;  /* Preferred icon size */
   display: inline-block;
+  width: 1em;
+  overflow: hidden;
   line-height: 1;
   text-transform: none;
   letter-spacing: normal;


### PR DESCRIPTION
Restricted icon width to 1em to avoid extraneous whitespace in the cases where the icon is improperly named, i.e. [issue 302](https://github.com/google/material-design-icons/issues/302) or [591](https://github.com/google/material-design-icons/issues/591
).
This way only one whitespace will be displayed if the user types `insert_image`, instead of multiple ones like before.
In the case of `image_badname` the `image` icon will be displayed correctly, instead of the `image` icon followed by 8 whitespaces.
Properly named icons will be displayed normally.

Also, `.editorconfig` file is added to keep editor and IDE rules consistent.