### PR TITLE
Add quote for url in iconfont/material-icons.css

### DIFF
--- a/iconfont/material-icons.css
+++ b/iconfont/material-icons.css
@@ -2,12 +2,12 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url(MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: url('MaterialIcons-Regular.eot'); /* For IE6-8 */
   src: local('Material Icons'),
        local('MaterialIcons-Regular'),
-       url(MaterialIcons-Regular.woff2) format('woff2'),
-       url(MaterialIcons-Regular.woff) format('woff'),
-       url(MaterialIcons-Regular.ttf) format('truetype');
+       url('MaterialIcons-Regular.woff2') format('woff2'),
+       url('MaterialIcons-Regular.woff') format('woff'),
+       url('MaterialIcons-Regular.ttf') format('truetype');
 }
 
 .material-icons {


### PR DESCRIPTION
Post-css parser workaround that comply with https://www.w3.org/TR/CSS1/#url