### PR TITLE
Change sprity/sprity-gm with spritesmith/gmsmith

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -4,7 +4,8 @@ import _ from 'lodash';
 import File from 'vinyl';
 import gulp from 'gulp';
 import merge from 'merge-stream';
-import sprity from 'sprity';
+import spritesmith from 'gulp.spritesmith';
+import gmsmith from 'gmsmith';
 import svgSprite from 'gulp-svg-sprite';
 import through2 from 'through2';
 import { humanize, titleize } from 'underscore.string';
@@ -44,82 +45,82 @@ const PNG_COLORS = [
  *
  * TODO(shyndman): Add support for double density sprites.
  */
-gulp.task('png-sprites', () =>
-  _(getCategoryColorPairs())
-    .map(([ category, color ]) =>
-      sprity.src({
-        src: `./${ category }/1x_web/*_${ color }_24dp.png`,
-        style: `sprite-${ category }-${ color }.css`,
-        name: `sprite-${ category }-${ color }`,
-        engine: 'sprity-gm',
-        orientation: 'left-right'
-      }))
-    .thru(merge)
+gulp.task( 'png-sprites', () =>
+  _( getCategoryColorPairs() )
+    .map( ( [ category, color ] ) =>
+      gulp.src( `./${category}/1x_web/*_${color}_24dp.png`, { read: false } )
+        .pipe( spritesmith( {
+          cssName: `sprite-${category}-${color}.css`,
+          imgName: `sprite-${category}-${color}`,
+          engine: gmsmith,
+          orientation: 'left-right'
+        } ) ) )
+    .thru( merge )
     .value()
-    .pipe(gulp.dest('./sprites/css-sprite/')));
+    .pipe( gulp.dest( './sprites/css-sprite/' ) ) );
 
 
 /**
  * Generates CSS and Symbol-based SVG sprites for each category, and places
  * them in `sprites/svg-sprite`.
  */
-gulp.task('svg-sprites', () =>
-  _(ICON_CATEGORIES)
-    .map((category) =>
-      gulp.src(`./${ category }/svg/production/*_24px.svg`)
-        .pipe(svgSprite(getSvgSpriteConfig(category))))
-    .thru(merge)
+gulp.task( 'svg-sprites', () =>
+  _( ICON_CATEGORIES )
+    .map( ( category ) =>
+      gulp.src( `./${category}/svg/production/*_24px.svg` )
+        .pipe( svgSprite( getSvgSpriteConfig( category ) ) ) )
+    .thru( merge )
     .value()
-    .pipe(gulp.dest('./sprites/svg-sprite')));
+    .pipe( gulp.dest( './sprites/svg-sprite' ) ) );
 
 
 /**
  * Generates a file to allow the consumption of the icon font by Iconjar
  * (http://geticonjar.com/).
  */
-gulp.task('iconjar', () =>
-  gulp.src('./iconfont/codepoints')
-    .pipe(generateIjmap('MaterialIcons-Regular.ijmap'))
-    .pipe(gulp.dest('./iconfont/')));
+gulp.task( 'iconjar', () =>
+  gulp.src( './iconfont/codepoints' )
+    .pipe( generateIjmap( 'MaterialIcons-Regular.ijmap' ) )
+    .pipe( gulp.dest( './iconfont/' ) ) );
 
 
 /** Runs all tasks. */
-gulp.task('default', ['png-sprites', 'svg-sprites', 'iconjar']);
+gulp.task( 'default', [ 'png-sprites', 'svg-sprites', 'iconjar' ] );
 
 
 /**
  * Returns a stream that transforms between our icon font's codepoint file
  * and an Iconjar ijmap.
  */
-function generateIjmap(ijmapPath) {
-  return through2.obj((codepointsFile, encoding, callback) => {
+function generateIjmap( ijmapPath ) {
+  return through2.obj( ( codepointsFile, encoding, callback ) => {
     const ijmap = {
-      icons: codepointsToIjmap(codepointsFile.contents.toString())
+      icons: codepointsToIjmap( codepointsFile.contents.toString() )
     };
 
-    callback(null, new File({
+    callback( null, new File( {
       path: ijmapPath,
-      contents: new Buffer(JSON.stringify(ijmap), 'utf8')
-    }));
+      contents: new Buffer( JSON.stringify( ijmap ), 'utf8' )
+    } ) );
 
-    function codepointsToIjmap(codepoints) {
-      return _(codepoints)
-        .split('\n')       // split into lines
-        .reject(_.isEmpty) // remove empty lines
-        .reduce((codepointMap, line) => {   // build up the codepoint map
-          let [ name, codepoint ] = line.split(' ');
-          codepointMap[codepoint] = { name: titleize(humanize(name)) };
+    function codepointsToIjmap( codepoints ) {
+      return _( codepoints )
+        .split( '\n' )       // split into lines
+        .reject( _.isEmpty ) // remove empty lines
+        .reduce( ( codepointMap, line ) => {   // build up the codepoint map
+          let [ name, codepoint ] = line.split( ' ' );
+          codepointMap[ codepoint ] = { name: titleize( humanize( name ) ) };
           return codepointMap;
-        }, {});
+        }, {} );
     }
-  });
+  } );
 }
 
 
 /**
  * Returns the SVG sprite configuration for the specified category.
  */
-function getSvgSpriteConfig(category) {
+function getSvgSpriteConfig( category ) {
   return {
     shape: {
       dimension: {
@@ -128,25 +129,25 @@ function getSvgSpriteConfig(category) {
       },
     },
     mode: {
-      css : {
+      css: {
         bust: false,
         dest: './',
-        sprite: `./svg-sprite-${ category }.svg`,
+        sprite: `./svg-sprite-${category}.svg`,
         example: {
-          dest: `./svg-sprite-${ category }.html`
+          dest: `./svg-sprite-${category}.html`
         },
         render: {
           css: {
-            dest: `./svg-sprite-${ category }.css`
+            dest: `./svg-sprite-${category}.css`
           }
         }
       },
-      symbol : {
+      symbol: {
         bust: false,
         dest: './',
-        sprite: `./svg-sprite-${ category }-symbol.svg`,
+        sprite: `./svg-sprite-${category}-symbol.svg`,
         example: {
-          dest: `./svg-sprite-${ category }-symbol.html`
+          dest: `./svg-sprite-${category}-symbol.html`
         }
       }
     }
@@ -158,9 +159,9 @@ function getSvgSpriteConfig(category) {
  * Returns the catesian product of categories and colors.
  */
 function getCategoryColorPairs() {
-  return _(ICON_CATEGORIES)
-    .map((category) =>
-      _.zip(_.times(PNG_COLORS.length, () => category), PNG_COLORS))
+  return _( ICON_CATEGORIES )
+    .map( ( category ) =>
+      _.zip( _.times( PNG_COLORS.length, () => category ), PNG_COLORS ) )
     .flatten() // flattens 1 level
     .value();
 }

--- a/package.json
+++ b/package.json
@@ -20,16 +20,16 @@
   },
   "homepage": "https://github.com/google/material-design-icons",
   "devDependencies": {
-    "babel-core": "^6.1.2",
-    "babel-preset-es2015": "^6.1.2",
-    "gulp": "^3.9.0",
-    "gulp-if": "^2.0.0",
-    "gulp-svg-sprite": "^1.2.14",
-    "lodash": "^3.10.1",
-    "sprity": "^1.0.8",
-    "sprity-gm": "^1.0.2",
-    "through2": "^2.0.0",
-    "underscore.string": "^3.2.2",
-    "vinyl": "^1.1.0"
+    "babel-core": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
+    "gmsmith": "^1.2.0",
+    "gulp": "^3.9.1",
+    "gulp-if": "^2.0.2",
+    "gulp-svg-sprite": "^1.4.0",
+    "gulp.spritesmith": "^6.9.0",
+    "lodash": "^4.17.10",
+    "through2": "^2.0.3",
+    "underscore.string": "^3.3.4",
+    "vinyl": "^2.1.0"
   }
 }


### PR DESCRIPTION
When Installing the sprity library the build of the required library
[lwip](https://github.com/EyalAr/lwip) fails on newer environments.
The 'png-sprites' gulp task also fails as consequence.

It seems lwip is an abandoned project at the moment.

That library can be replaced by the [spritesmith](https://github.com/Ensighten/spritesmith) toolkit which aims
to do the same task.

Also all relevant libraries are upgraded to the latest stable version.