### PR TITLE
Ligature Support in Microsoft Edge on Website

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,10 @@ devices.</p>
     <td>10</td>
  </tr>
  <tr>
+    <td>Microsoft Edge</td>
+    <td>18</td>
+ </tr>
+ <tr>
     <td>Opera</td>
     <td>15</td>
  </tr>


### PR DESCRIPTION
Microsoft Edge has replaced Internet Explorer on Windows and so it would be appropriate that the Microsoft Edge version that supported ligatures is on the ligature support table in the website. 

I used the following website to find the version at which ligatures were supported in Microsoft Edge: [https://caniuse.com/#feat=font-feature](https://caniuse.com/#feat=font-feature.)

Please let me know if there is anything else that I can change!