### PR TITLE
Fixed: Broken self-hosted link

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@ An additional CSS class will be declared called <code>.material-icons</code>.
 Any element that uses this class will have the correct CSS to render these icons from the web font.</p>
 <h2 id="setup-method-2-self-hosting">Setup Method 2. Self hosting</h2>
 <p>For those looking to self host the web font, some additional setup is necessary.
-Host the <a href="https://github.com/google/material-design-icons/tree/master/iconfont">icon font</a> in a location, for example <code>https://example.com/material-icons.woff</code> and add the
+Host the <a href="https://github.com/google/material-design-icons/tree/master/font">icon font</a> in a location, for example <code>https://example.com/material-icons.woff</code> and add the
 following CSS rule:</p>
 <pre><code class="lang-css">@font-face {
   font-family: &#39;Material Icons&#39;;


### PR DESCRIPTION
https://github.com/google/material-design-icons/tree/master/iconfont -> https://github.com/google/material-design-icons/tree/master/font