### PR TITLE
Remove duplicate star_outline codepoint

### DIFF
--- a/font/MaterialIcons-Regular.codepoints
+++ b/font/MaterialIcons-Regular.codepoints
@@ -1330,7 +1330,6 @@ stairs f1a9
 star e838
 star_border e83a
 star_half e839
-star_outline e83a
 star_outline f06f
 star_rate f0ec
 stars e8d0


### PR DESCRIPTION
`star_border` and `star_outline` seem to be idential anyways!?