### PR TITLE
Update outdated link

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@ the icons themselves.</p>
 suitable for web, Android, and iOS projects or for inclusion in any designer
 tools.</p>
 <h2 id="downloading-everything">Downloading everything</h2>
-<p>Grab the <a href="https://github.com/google/material-design-icons/releases/download/3.0.1/material-design-icons-3.0.1.zip">latest stable zip archive</a> (~60MB) of all icons or the <a href="https://github.com/google/material-design-icons/archive/master.zip">bleeding-edge version from master.</a></p>
+<p>Grab the <a href="https://codeload.github.com/google/material-design-icons/zip/refs/tags/4.0.0">latest stable zip archive</a> (~100MB) of all icons.</p>
 <h2 id="git-repository">Git Repository</h2>
 <p>The material icons are available from the <a href="https://github.com/google/material-design-icons">git repository</a> which contains the complete set of icons including all the various formats we
 are making available.</p>


### PR DESCRIPTION
The link 『[http://google.github.io/material-design-icons#downloading-everything](http://google.github.io/material-design-icons#downloading-everything)』is outdated (which links to v3.0.1)