### PR TITLE
Remove links to sprites directory

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,7 +366,7 @@ Individual icons are downloadable from the <a href="https://www.google.com/desig
 </code></pre><p>For example, icons for maps are in <a href="https://github.com/google/material-design-icons/tree/master/maps/svg/production">maps/svg/production</a>:</p>
 <pre><code>material-design-icons/maps/svg/production/
 </code></pre><p>If multiple icons are in use on a web site, creating spritesheets out of the
-images is recommended. For more information, refer to the documentation in the <a href="https://github.com/google/material-design-icons/tree/master/sprites">sprites directory of the git repository</a>.</p>
+images is recommended.</p>
 <h2 id="png">PNG</h2>
 <p>PNG is the most traditional way to display icons on the web. Our downloads from
 the <a href="https://www.google.com/design/icons/">material icons library</a> provide both single and double densities for each icon. They are referred to
@@ -375,7 +375,7 @@ under:</p>
 <pre><code>material-design-icons/*/1x_web/
 material-design-icons/*/2x_web/
 </code></pre><p>If multiple icons are in use on a web site, creating spritesheets out of the
-images is recommended. For more information, refer to recommendations in the <a href="https://github.com/google/material-design-icons/tree/master/sprites">sprites directory in the git repository</a>.</p>
+images is recommended.</p>
 <p><hr></p>
 <h1 id="icons-for-android">Icons for Android</h1>
 <p>PNGs suitable for Android are available from the <a href="https://www.google.com/design/icons/">material icons library</a>. These come in all the supported screen densities so they should look good on


### PR DESCRIPTION
The sprites directory has been removed with v4.0.0 and the links now return a 404 - not found.