### PR TITLE
Update main.yml to use ubuntu-latest as runner Fixes #1902

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   update-symbols:
     permissions:
       contents: write
-    runs-on: ubuntu-20.04-4core
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:


### PR DESCRIPTION
This allows the main.yaml to not fail when running.
The main.yaml action has not been able to finish running in months and this change to use `ubuntu-latest` as the runner instead of `ubuntu-20.04-4core` fixes the issue and allows the fonts to be generated correctly.