### PR TITLE
Update main.yml to correct docker rmi command. Fixes #1927

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         sudo swapoff -a
         sudo rm -f /swapfile
         sudo apt clean
-        docker rmi $(docker image ls -aq)
+        docker image prune -a -f
         df -h
     - uses: actions/checkout@v3
     - name: Set up Python


### PR DESCRIPTION
This replaces the failing `docker rmi $(docker image ls -aq)` command with the more flexible and versatile `docker image prune -a -f` command.

The `docker image prune -a -f` command will prune images from previous runs if they are present, and will do nothing if there are no old images present.   This accomplishes the same thing that the ` docker rmi $(docker image ls -aq)` was trying to accomplish (but was failing when there were no previous/old images to find/delete)