### PR TITLE
docs: update deprecated documentation URLs and add font URL deprecati…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ These are two different official icon sets from Google, using the same underlyin
 
 The icons can be browsed in a more user-friendly way at https://fonts.google.com/icons. Use the popdown menu near top left to choose between the two sets; Material Symbols is the default.
 
-The icons are designed under the [material design guidelines](https://material.io/guidelines/).
+The icons are designed under the [material design guidelines](https://m2.material.io/design/iconography/system-icons.html).
 
 ## Icon Requests
 
@@ -132,6 +132,9 @@ The `font` and `variablefont` folders contain pre-generated font files that can 
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
       rel="stylesheet">
 ```
+
+> **Note:** The older `https://fonts.googleapis.com/icon?family=Material+Icons` URL format is deprecated and may fail to load. Use the `css2` URL format shown above instead.
+
 Read more on [Material Symbols](https://developers.google.com/fonts/docs/material_symbols/) or [Material Icons](https://developers.google.com/fonts/docs/material_icons/) in the Google Fonts developer guide.
 
 

--- a/font/README.md
+++ b/font/README.md
@@ -5,24 +5,26 @@ Material Icons are the non-variable classic icon fonts, while the Material Symbo
 The recommended way to use the Material Icons font is by linking to the web font hosted on Google Fonts:
 
 ```html
-<!-- https://material.io/resources/icons/?style=baseline -->
+<!-- https://fonts.google.com/icons?icon.set=Material+Icons&icon.style=Filled -->
 <link href="https://fonts.googleapis.com/css2?family=Material+Icons"
       rel="stylesheet">
 
-<!-- https://material.io/resources/icons/?style=outline -->
+<!-- https://fonts.google.com/icons?icon.set=Material+Icons&icon.style=Outlined -->
 <link href="https://fonts.googleapis.com/css2?family=Material+Icons+Outlined"
       rel="stylesheet">
 
-<!-- https://material.io/resources/icons/?style=round -->
+<!-- https://fonts.google.com/icons?icon.set=Material+Icons&icon.style=Rounded -->
 <link href="https://fonts.googleapis.com/css2?family=Material+Icons+Round"
       rel="stylesheet">
 
-<!-- https://material.io/resources/icons/?style=sharp -->
+<!-- https://fonts.google.com/icons?icon.set=Material+Icons&icon.style=Sharp -->
 <link href="https://fonts.googleapis.com/css2?family=Material+Icons+Sharp"
       rel="stylesheet">
 
-<!-- https://material.io/resources/icons/?style=twotone -->
+<!-- https://fonts.google.com/icons?icon.set=Material+Icons&icon.style=Two+tone -->
 <link href="https://fonts.googleapis.com/css2?family=Material+Icons+Two+Tone"
       rel="stylesheet">
 ```
+
+> **Note:** The older `https://fonts.googleapis.com/icon?family=Material+Icons` URL format is deprecated and may fail to load. Use the `css2` URL format shown above instead.
 


### PR DESCRIPTION
Closes #1486

The `https://fonts.googleapis.com/icon?family=Material+Icons` URL format is deprecated and causes connection timeouts for some users (see #1486).

Changes:
- Updated the material design guidelines link in `README.md` from the defunct `material.io/guidelines/` URL to `m2.material.io/design/iconography/system-icons.html`
- Updated the icon browser comment URLs in `font/README.md` from the deprecated `material.io/resources/icons/` format to the current `fonts.google.com/icons` URLs
- Added a deprecation warning in both `README.md` and `font/README.md` explicitly noting that the old `icon?family=` URL format is deprecated and directing users to the `css2?family=` replacement